### PR TITLE
Add isActive() and isEnded() to StateMachineInterface and etc.

### DIFF
--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -14,6 +14,7 @@ namespace Stagehand\FSM\StateMachine;
 
 use Stagehand\FSM\Event\EventInterface;
 use Stagehand\FSM\Event\TransitionEventInterface;
+use Stagehand\FSM\State\FinalState;
 use Stagehand\FSM\State\State;
 use Stagehand\FSM\State\StateCollection;
 use Stagehand\FSM\State\StateInterface;
@@ -389,13 +390,21 @@ class StateMachine implements StateMachineInterface, \Serializable
     }
 
     /**
-     * @return bool
+     * {@inheritDoc}
      *
      * @since Method available since Release 2.3.0
      */
     public function isActive()
     {
         return $this->active;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEnded()
+    {
+        return count($this->transitionLogs) > 0 && $this->transitionLogs[count($this->transitionLogs) - 1]->getToState() instanceof FinalState;
     }
 
     /**

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -295,10 +295,6 @@ class StateMachine implements StateMachineInterface, \Serializable
      */
     public function triggerEvent($eventId)
     {
-        if (!$this->active) {
-            throw $this->createStateMachineNotStartedException();
-        }
-
         $this->queueEvent($eventId);
 
         do {

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -326,7 +326,11 @@ class StateMachine implements StateMachineInterface, \Serializable
     public function queueEvent($eventId)
     {
         if (!$this->active) {
-            throw $this->createStateMachineNotStartedException();
+            if ($this->isEnded()) {
+                throw new StateMachineAlreadyShutdownException('The state machine was already shutdown.');
+            } else {
+                throw $this->createStateMachineNotStartedException();
+            }
         }
 
         $this->eventQueue[] = $eventId;

--- a/src/StateMachine/StateMachineInterface.php
+++ b/src/StateMachine/StateMachineInterface.php
@@ -108,4 +108,11 @@ interface StateMachineInterface extends EntityInterface
      * @throws StateMachineNotStartedException
      */
     public function queueEvent($eventId);
+
+    /**
+     * @return bool
+     *
+     * @since Method available since Release 2.4.0
+     */
+    public function isActive();
 }

--- a/src/StateMachine/StateMachineInterface.php
+++ b/src/StateMachine/StateMachineInterface.php
@@ -115,4 +115,11 @@ interface StateMachineInterface extends EntityInterface
      * @since Method available since Release 2.4.0
      */
     public function isActive();
+
+    /**
+     * @return bool
+     *
+     * @since Method available since Release 2.4.0
+     */
+    public function isEnded();
 }

--- a/src/StateMachine/StateMachineInterface.php
+++ b/src/StateMachine/StateMachineInterface.php
@@ -105,6 +105,7 @@ interface StateMachineInterface extends EntityInterface
      *
      * @param string $eventId
      *
+     * @throws StateMachineAlreadyShutdownException
      * @throws StateMachineNotStartedException
      */
     public function queueEvent($eventId);


### PR DESCRIPTION
This adds `isActive()` and `isEnded()` to `StateMachineInterface`. #14 #16
And also  this changes `queueEvent()` to throw an exception after the state machine is ended. #17