### PR TITLE
Add getTransitionLogs() to StateMachineInterface

### DIFF
--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -389,7 +389,7 @@ class StateMachine implements StateMachineInterface, \Serializable
     }
 
     /**
-     * @return TransitionLog[]
+     * {@inheritDoc}
      */
     public function getTransitionLogs()
     {

--- a/src/StateMachine/StateMachineInterface.php
+++ b/src/StateMachine/StateMachineInterface.php
@@ -123,4 +123,11 @@ interface StateMachineInterface extends EntityInterface
      * @since Method available since Release 2.4.0
      */
     public function isEnded();
+
+    /**
+     * @return TransitionLog[]
+     *
+     * @since Method available since Release 2.4.0
+     */
+    public function getTransitionLogs();
 }


### PR DESCRIPTION
This PR adds `getTransitionLogs()` to `StateMachineInterface`. #19