### PR TITLE
Upgrading the minimum required PHP Version to 7.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.0.8",
         "phpmentors/domain-kata": "~1.4",
         "symfony/event-dispatcher": "~2.3"
     },

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,7 +2,7 @@ version: '2'
 services:
     app:
         container_name: "piece.stagehand-fsm.app"
-        image: "phpmentors/php-app:php53"
+        image: "phpmentors/php-app:php70"
         volumes:
             - ".:/var/app"
         environment:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #22
| License       | BSD-2-Clause

This will change the minimum required PHP version to `7.0.8`.
