### PR TITLE
New minimum required Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.0.8",
         "phpmentors/domain-kata": "~1.4",
-        "symfony/event-dispatcher": "~2.3"
+        "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "require-dev": {
         "phake/phake": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | BSD-2-Clause

This will change the the minimum required version of symfony/event-dispatcher to `~2.8` or `~3.0`.
